### PR TITLE
add user node pool & availability zones

### DIFF
--- a/.github/ISSUE_TEMPLATE/avm_module_issue.yml
+++ b/.github/ISSUE_TEMPLATE/avm_module_issue.yml
@@ -1,0 +1,70 @@
+name: AVM - Module Issue ➕🐛🔒
+description: Want to request a new Module feature or report a bug? Let us know!
+title: "[AVM Module Issue]: "
+labels: ["Needs: Triage :mag:", "Language: Terraform :globe_with_meridians:"]
+projects: ["Azure/566"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting this AVM Module Issue!
+
+        To help us triage your issue, please provide the below details.
+
+        > **NOTE**: If you'd like to propose a new AVM module, please follow the process described in the [AVM repo](https://aka.ms/AVM/ModuleProposal).
+  - type: checkboxes
+    id: existing-checks
+    attributes:
+      label: Check for previous/existing GitHub issues
+      description: By submitting this issue, you confirm that you have searched for previous/existing GitHub issues to avoid creating a duplicate.
+      options:
+        - label: I have checked for previous/existing GitHub issues
+          required: true
+  - type: checkboxes
+    id: module-specific-checks
+    attributes:
+      label: Module specific issue
+      description: By submitting this issue, you confirm that this issue is about this AVM module and not about the resource itself, or how to use Terraform.
+      options:
+        - label: I confirm that this issue is about this AVM module and not about the resource itself, or how to use Terraform.
+          required: true
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type?
+      description: How would you best describe this issue? Is this a...
+      options:
+        - "Feature Request"
+        - "Bug"
+        - "Security Bug"
+        - "I'm not sure"
+    validations:
+      required: true
+  - type: input
+    id: module-version
+    attributes:
+      label: (Optional) Module Version
+      description: Please provide which version(s) of the module does this issue apply to.
+    validations:
+      required: false
+  - type: input
+    id: correlation-id
+    attributes:
+      label: (Optional) Correlation Id
+      description: Please provide a correlation id if available and appropriate.
+    validations:
+      required: false
+  - type: textarea
+    id: question-feedback-text
+    attributes:
+      label: Description
+      description: |
+        Please describe the issue!
+        > **NOTE**: All requested features must already be supported by the provider and Preview Services ([SFR1](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-sfr1---category-composition---preview-services)) are not supported.
+      placeholder: |
+        <!--
+        If this is a bug, please provide a minimum example to reproduce the bug.
+        If this is a feature request, please provide a detailed description of the feature.
+        -->
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!--
+>Thank you for your contribution !
+> Please include a summary of the change and which issue is fixed.
+> Please also include the context.
+> List any dependencies that are required for this change.
+
+Fixes #123
+Closes #456
+-->
+
+## Type of Change
+
+<!-- Use the check-boxes [x] on the options that are relevant. -->
+
+- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
+- [ ] Azure Verified Module updates:
+  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
+    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
+    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
+  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
+  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
+  - [ ] Update to documentation
+
+# Checklist
+
+- [ ] I'm sure there are no other open Pull Requests for the same update/change
+- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
+- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
+
+<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,6 @@ jobs:
     strategy:
       matrix:
         example: ${{ fromJson(needs.getexamples.outputs.examples) }}
-      max-parallel: 5
       fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
@@ -48,7 +47,8 @@ jobs:
           az login --identity --username $MSI_ID > /dev/null
           export ARM_SUBSCRIPTION_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .id')
           export ARM_TENANT_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .tenantId')
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_USE_MSI=true mcr.microsoft.com/azterraform:latest make test-example
+          export ARM_CLIENT_ID=$(az identity list | jq -r --arg MSI_ID "$MSI_ID" '.[] | select(.principalId == $MSI_ID) | .clientId')
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e ARM_USE_MSI=true mcr.microsoft.com/azterraform:latest make test-example
 
   # This job is only run when all the previous jobs are successful.
   # We can use it for PR validation to ensure all examples have completed.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ README-generated.md
 avm.tflint.hcl
 avm.tflint_example.hcl
 *tfplan*
+.DS_Store*
+*.md.tmp
+.DS_Store
+avm.tflint.merged.hcl
+avm.tflint_example.merged.hcl

--- a/avm
+++ b/avm
@@ -18,4 +18,4 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-$CONTAINER_RUNTIME run --rm -v "$(pwd)":/src -w /src mcr.microsoft.com/azterraform make "$1"
+$CONTAINER_RUNTIME run --pull always --rm -v "$(pwd)":/src -w /src -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"

--- a/avm.bat
+++ b/avm.bat
@@ -18,6 +18,6 @@ IF "%~1"=="" (
 )
 
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --rm -v "%cd%":/src -w /src mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
 
 ENDLOCAL

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,1432 @@
+{
+  "value": [
+    {
+      "displayName": "East US",
+      "id": "/locations/eastus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "37.3719",
+        "longitude": "-79.8164",
+        "pairedRegion": [
+          {
+            "id": "/locations/westus",
+            "name": "westus"
+          }
+        ],
+        "physicalLocation": "Virginia",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "eastus",
+      "regionalDisplayName": "(US) East US",
+      "type": "Region"
+    },
+    {
+      "displayName": "East US 2",
+      "id": "/locations/eastus2",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "36.6681",
+        "longitude": "-78.3889",
+        "pairedRegion": [
+          {
+            "id": "/locations/centralus",
+            "name": "centralus"
+          }
+        ],
+        "physicalLocation": "Virginia",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "eastus2",
+      "regionalDisplayName": "(US) East US 2",
+      "type": "Region"
+    },
+    {
+      "displayName": "South Central US",
+      "id": "/locations/southcentralus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "29.4167",
+        "longitude": "-98.5",
+        "pairedRegion": [
+          {
+            "id": "/locations/northcentralus",
+            "name": "northcentralus"
+          }
+        ],
+        "physicalLocation": "Texas",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "southcentralus",
+      "regionalDisplayName": "(US) South Central US",
+      "type": "Region"
+    },
+    {
+      "displayName": "West US 2",
+      "id": "/locations/westus2",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "47.233",
+        "longitude": "-119.852",
+        "pairedRegion": [
+          {
+            "id": "/locations/westcentralus",
+            "name": "westcentralus"
+          }
+        ],
+        "physicalLocation": "Washington",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "westus2",
+      "regionalDisplayName": "(US) West US 2",
+      "type": "Region"
+    },
+    {
+      "displayName": "West US 3",
+      "id": "/locations/westus3",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "33.448376",
+        "longitude": "-112.074036",
+        "pairedRegion": [
+          {
+            "id": "/locations/eastus",
+            "name": "eastus"
+          }
+        ],
+        "physicalLocation": "Phoenix",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "westus3",
+      "regionalDisplayName": "(US) West US 3",
+      "type": "Region"
+    },
+    {
+      "displayName": "Australia East",
+      "id": "/locations/australiaeast",
+      "metadata": {
+        "geography": "Australia",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "-33.86",
+        "longitude": "151.2094",
+        "pairedRegion": [
+          {
+            "id": "/locations/australiasoutheast",
+            "name": "australiasoutheast"
+          }
+        ],
+        "physicalLocation": "New South Wales",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "australiaeast",
+      "regionalDisplayName": "(Asia Pacific) Australia East",
+      "type": "Region"
+    },
+    {
+      "displayName": "Southeast Asia",
+      "id": "/locations/southeastasia",
+      "metadata": {
+        "geography": "Asia Pacific",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "1.283",
+        "longitude": "103.833",
+        "pairedRegion": [
+          {
+            "id": "/locations/eastasia",
+            "name": "eastasia"
+          }
+        ],
+        "physicalLocation": "Singapore",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "southeastasia",
+      "regionalDisplayName": "(Asia Pacific) Southeast Asia",
+      "type": "Region"
+    },
+    {
+      "displayName": "North Europe",
+      "id": "/locations/northeurope",
+      "metadata": {
+        "geography": "Europe",
+        "geographyGroup": "Europe",
+        "latitude": "53.3478",
+        "longitude": "-6.2597",
+        "pairedRegion": [
+          {
+            "id": "/locations/westeurope",
+            "name": "westeurope"
+          }
+        ],
+        "physicalLocation": "Ireland",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "northeurope",
+      "regionalDisplayName": "(Europe) North Europe",
+      "type": "Region"
+    },
+    {
+      "displayName": "Sweden Central",
+      "id": "/locations/swedencentral",
+      "metadata": {
+        "geography": "Sweden",
+        "geographyGroup": "Europe",
+        "latitude": "60.67488",
+        "longitude": "17.14127",
+        "pairedRegion": [
+          {
+            "id": "/locations/swedensouth",
+            "name": "swedensouth"
+          }
+        ],
+        "physicalLocation": "Gävle",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "swedencentral",
+      "regionalDisplayName": "(Europe) Sweden Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "UK South",
+      "id": "/locations/uksouth",
+      "metadata": {
+        "geography": "United Kingdom",
+        "geographyGroup": "Europe",
+        "latitude": "50.941",
+        "longitude": "-0.799",
+        "pairedRegion": [
+          {
+            "id": "/locations/ukwest",
+            "name": "ukwest"
+          }
+        ],
+        "physicalLocation": "London",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "uksouth",
+      "regionalDisplayName": "(Europe) UK South",
+      "type": "Region"
+    },
+    {
+      "displayName": "West Europe",
+      "id": "/locations/westeurope",
+      "metadata": {
+        "geography": "Europe",
+        "geographyGroup": "Europe",
+        "latitude": "52.3667",
+        "longitude": "4.9",
+        "pairedRegion": [
+          {
+            "id": "/locations/northeurope",
+            "name": "northeurope"
+          }
+        ],
+        "physicalLocation": "Netherlands",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "westeurope",
+      "regionalDisplayName": "(Europe) West Europe",
+      "type": "Region"
+    },
+    {
+      "displayName": "Central US",
+      "id": "/locations/centralus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "41.5908",
+        "longitude": "-93.6208",
+        "pairedRegion": [
+          {
+            "id": "/locations/eastus2",
+            "name": "eastus2"
+          }
+        ],
+        "physicalLocation": "Iowa",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "centralus",
+      "regionalDisplayName": "(US) Central US",
+      "type": "Region"
+    },
+    {
+      "displayName": "South Africa North",
+      "id": "/locations/southafricanorth",
+      "metadata": {
+        "geography": "South Africa",
+        "geographyGroup": "Africa",
+        "latitude": "-25.73134",
+        "longitude": "28.21837",
+        "pairedRegion": [
+          {
+            "id": "/locations/southafricawest",
+            "name": "southafricawest"
+          }
+        ],
+        "physicalLocation": "Johannesburg",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "southafricanorth",
+      "regionalDisplayName": "(Africa) South Africa North",
+      "type": "Region"
+    },
+    {
+      "displayName": "Central India",
+      "id": "/locations/centralindia",
+      "metadata": {
+        "geography": "India",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "18.5822",
+        "longitude": "73.9197",
+        "pairedRegion": [
+          {
+            "id": "/locations/southindia",
+            "name": "southindia"
+          }
+        ],
+        "physicalLocation": "Pune",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "centralindia",
+      "regionalDisplayName": "(Asia Pacific) Central India",
+      "type": "Region"
+    },
+    {
+      "displayName": "East Asia",
+      "id": "/locations/eastasia",
+      "metadata": {
+        "geography": "Asia Pacific",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "22.267",
+        "longitude": "114.188",
+        "pairedRegion": [
+          {
+            "id": "/locations/southeastasia",
+            "name": "southeastasia"
+          }
+        ],
+        "physicalLocation": "Hong Kong",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "eastasia",
+      "regionalDisplayName": "(Asia Pacific) East Asia",
+      "type": "Region"
+    },
+    {
+      "displayName": "Japan East",
+      "id": "/locations/japaneast",
+      "metadata": {
+        "geography": "Japan",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "35.68",
+        "longitude": "139.77",
+        "pairedRegion": [
+          {
+            "id": "/locations/japanwest",
+            "name": "japanwest"
+          }
+        ],
+        "physicalLocation": "Tokyo, Saitama",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "japaneast",
+      "regionalDisplayName": "(Asia Pacific) Japan East",
+      "type": "Region"
+    },
+    {
+      "displayName": "Korea Central",
+      "id": "/locations/koreacentral",
+      "metadata": {
+        "geography": "Korea",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "37.5665",
+        "longitude": "126.978",
+        "pairedRegion": [
+          {
+            "id": "/locations/koreasouth",
+            "name": "koreasouth"
+          }
+        ],
+        "physicalLocation": "Seoul",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "koreacentral",
+      "regionalDisplayName": "(Asia Pacific) Korea Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Canada Central",
+      "id": "/locations/canadacentral",
+      "metadata": {
+        "geography": "Canada",
+        "geographyGroup": "Canada",
+        "latitude": "43.653",
+        "longitude": "-79.383",
+        "pairedRegion": [
+          {
+            "id": "/locations/canadaeast",
+            "name": "canadaeast"
+          }
+        ],
+        "physicalLocation": "Toronto",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "canadacentral",
+      "regionalDisplayName": "(Canada) Canada Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "France Central",
+      "id": "/locations/francecentral",
+      "metadata": {
+        "geography": "France",
+        "geographyGroup": "Europe",
+        "latitude": "46.3772",
+        "longitude": "2.373",
+        "pairedRegion": [
+          {
+            "id": "/locations/francesouth",
+            "name": "francesouth"
+          }
+        ],
+        "physicalLocation": "Paris",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "francecentral",
+      "regionalDisplayName": "(Europe) France Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Germany West Central",
+      "id": "/locations/germanywestcentral",
+      "metadata": {
+        "geography": "Germany",
+        "geographyGroup": "Europe",
+        "latitude": "50.110924",
+        "longitude": "8.682127",
+        "pairedRegion": [
+          {
+            "id": "/locations/germanynorth",
+            "name": "germanynorth"
+          }
+        ],
+        "physicalLocation": "Frankfurt",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "germanywestcentral",
+      "regionalDisplayName": "(Europe) Germany West Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Italy North",
+      "id": "/locations/italynorth",
+      "metadata": {
+        "geography": "Italy",
+        "geographyGroup": "Europe",
+        "latitude": "45.46888",
+        "longitude": "9.18109",
+        "pairedRegion": [],
+        "physicalLocation": "Milan",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "italynorth",
+      "regionalDisplayName": "(Europe) Italy North",
+      "type": "Region"
+    },
+    {
+      "displayName": "Norway East",
+      "id": "/locations/norwayeast",
+      "metadata": {
+        "geography": "Norway",
+        "geographyGroup": "Europe",
+        "latitude": "59.913868",
+        "longitude": "10.752245",
+        "pairedRegion": [
+          {
+            "id": "/locations/norwaywest",
+            "name": "norwaywest"
+          }
+        ],
+        "physicalLocation": "Norway",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "norwayeast",
+      "regionalDisplayName": "(Europe) Norway East",
+      "type": "Region"
+    },
+    {
+      "displayName": "Poland Central",
+      "id": "/locations/polandcentral",
+      "metadata": {
+        "geography": "Poland",
+        "geographyGroup": "Europe",
+        "latitude": "52.23334",
+        "longitude": "21.01666",
+        "pairedRegion": [],
+        "physicalLocation": "Warsaw",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "polandcentral",
+      "regionalDisplayName": "(Europe) Poland Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Switzerland North",
+      "id": "/locations/switzerlandnorth",
+      "metadata": {
+        "geography": "Switzerland",
+        "geographyGroup": "Europe",
+        "latitude": "47.451542",
+        "longitude": "8.564572",
+        "pairedRegion": [
+          {
+            "id": "/locations/switzerlandwest",
+            "name": "switzerlandwest"
+          }
+        ],
+        "physicalLocation": "Zurich",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "switzerlandnorth",
+      "regionalDisplayName": "(Europe) Switzerland North",
+      "type": "Region"
+    },
+    {
+      "displayName": "UAE North",
+      "id": "/locations/uaenorth",
+      "metadata": {
+        "geography": "UAE",
+        "geographyGroup": "Middle East",
+        "latitude": "25.266666",
+        "longitude": "55.316666",
+        "pairedRegion": [
+          {
+            "id": "/locations/uaecentral",
+            "name": "uaecentral"
+          }
+        ],
+        "physicalLocation": "Dubai",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "uaenorth",
+      "regionalDisplayName": "(Middle East) UAE North",
+      "type": "Region"
+    },
+    {
+      "displayName": "Brazil South",
+      "id": "/locations/brazilsouth",
+      "metadata": {
+        "geography": "Brazil",
+        "geographyGroup": "South America",
+        "latitude": "-23.55",
+        "longitude": "-46.633",
+        "pairedRegion": [
+          {
+            "id": "/locations/southcentralus",
+            "name": "southcentralus"
+          }
+        ],
+        "physicalLocation": "Sao Paulo State",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "brazilsouth",
+      "regionalDisplayName": "(South America) Brazil South",
+      "type": "Region"
+    },
+    {
+      "displayName": "Israel Central",
+      "id": "/locations/israelcentral",
+      "metadata": {
+        "geography": "Israel",
+        "geographyGroup": "Middle East",
+        "latitude": "31.2655698",
+        "longitude": "33.4506633",
+        "pairedRegion": [],
+        "physicalLocation": "Israel",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "israelcentral",
+      "regionalDisplayName": "(Middle East) Israel Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Qatar Central",
+      "id": "/locations/qatarcentral",
+      "metadata": {
+        "geography": "Qatar",
+        "geographyGroup": "Middle East",
+        "latitude": "25.551462",
+        "longitude": "51.439327",
+        "pairedRegion": [],
+        "physicalLocation": "Doha",
+        "regionCategory": "Recommended",
+        "regionType": "Physical"
+      },
+      "name": "qatarcentral",
+      "regionalDisplayName": "(Middle East) Qatar Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Central US (Stage)",
+      "id": "/locations/centralusstage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "centralusstage",
+      "regionalDisplayName": "(US) Central US (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "East US (Stage)",
+      "id": "/locations/eastusstage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "eastusstage",
+      "regionalDisplayName": "(US) East US (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "East US 2 (Stage)",
+      "id": "/locations/eastus2stage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "eastus2stage",
+      "regionalDisplayName": "(US) East US 2 (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "North Central US (Stage)",
+      "id": "/locations/northcentralusstage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "northcentralusstage",
+      "regionalDisplayName": "(US) North Central US (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "South Central US (Stage)",
+      "id": "/locations/southcentralusstage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "southcentralusstage",
+      "regionalDisplayName": "(US) South Central US (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "West US (Stage)",
+      "id": "/locations/westusstage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "westusstage",
+      "regionalDisplayName": "(US) West US (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "West US 2 (Stage)",
+      "id": "/locations/westus2stage",
+      "metadata": {
+        "geography": "usa",
+        "geographyGroup": "US",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "westus2stage",
+      "regionalDisplayName": "(US) West US 2 (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "Asia",
+      "id": "/locations/asia",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "asia",
+      "regionalDisplayName": "Asia",
+      "type": "Region"
+    },
+    {
+      "displayName": "Asia Pacific",
+      "id": "/locations/asiapacific",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "asiapacific",
+      "regionalDisplayName": "Asia Pacific",
+      "type": "Region"
+    },
+    {
+      "displayName": "Australia",
+      "id": "/locations/australia",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "australia",
+      "regionalDisplayName": "Australia",
+      "type": "Region"
+    },
+    {
+      "displayName": "Brazil",
+      "id": "/locations/brazil",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "brazil",
+      "regionalDisplayName": "Brazil",
+      "type": "Region"
+    },
+    {
+      "displayName": "Canada",
+      "id": "/locations/canada",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "canada",
+      "regionalDisplayName": "Canada",
+      "type": "Region"
+    },
+    {
+      "displayName": "Europe",
+      "id": "/locations/europe",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "europe",
+      "regionalDisplayName": "Europe",
+      "type": "Region"
+    },
+    {
+      "displayName": "France",
+      "id": "/locations/france",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "france",
+      "regionalDisplayName": "France",
+      "type": "Region"
+    },
+    {
+      "displayName": "Germany",
+      "id": "/locations/germany",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "germany",
+      "regionalDisplayName": "Germany",
+      "type": "Region"
+    },
+    {
+      "displayName": "Global",
+      "id": "/locations/global",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "global",
+      "regionalDisplayName": "Global",
+      "type": "Region"
+    },
+    {
+      "displayName": "India",
+      "id": "/locations/india",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "india",
+      "regionalDisplayName": "India",
+      "type": "Region"
+    },
+    {
+      "displayName": "Japan",
+      "id": "/locations/japan",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "japan",
+      "regionalDisplayName": "Japan",
+      "type": "Region"
+    },
+    {
+      "displayName": "Korea",
+      "id": "/locations/korea",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "korea",
+      "regionalDisplayName": "Korea",
+      "type": "Region"
+    },
+    {
+      "displayName": "Norway",
+      "id": "/locations/norway",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "norway",
+      "regionalDisplayName": "Norway",
+      "type": "Region"
+    },
+    {
+      "displayName": "Singapore",
+      "id": "/locations/singapore",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "singapore",
+      "regionalDisplayName": "Singapore",
+      "type": "Region"
+    },
+    {
+      "displayName": "South Africa",
+      "id": "/locations/southafrica",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "southafrica",
+      "regionalDisplayName": "South Africa",
+      "type": "Region"
+    },
+    {
+      "displayName": "Sweden",
+      "id": "/locations/sweden",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "sweden",
+      "regionalDisplayName": "Sweden",
+      "type": "Region"
+    },
+    {
+      "displayName": "Switzerland",
+      "id": "/locations/switzerland",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "switzerland",
+      "regionalDisplayName": "Switzerland",
+      "type": "Region"
+    },
+    {
+      "displayName": "United Arab Emirates",
+      "id": "/locations/uae",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "uae",
+      "regionalDisplayName": "United Arab Emirates",
+      "type": "Region"
+    },
+    {
+      "displayName": "United Kingdom",
+      "id": "/locations/uk",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "uk",
+      "regionalDisplayName": "United Kingdom",
+      "type": "Region"
+    },
+    {
+      "displayName": "United States",
+      "id": "/locations/unitedstates",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "unitedstates",
+      "regionalDisplayName": "United States",
+      "type": "Region"
+    },
+    {
+      "displayName": "United States EUAP",
+      "id": "/locations/unitedstateseuap",
+      "metadata": {
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "unitedstateseuap",
+      "regionalDisplayName": "United States EUAP",
+      "type": "Region"
+    },
+    {
+      "displayName": "East Asia (Stage)",
+      "id": "/locations/eastasiastage",
+      "metadata": {
+        "geography": "asia",
+        "geographyGroup": "Asia Pacific",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "eastasiastage",
+      "regionalDisplayName": "(Asia Pacific) East Asia (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "Southeast Asia (Stage)",
+      "id": "/locations/southeastasiastage",
+      "metadata": {
+        "geography": "asia",
+        "geographyGroup": "Asia Pacific",
+        "regionCategory": "Other",
+        "regionType": "Logical"
+      },
+      "name": "southeastasiastage",
+      "regionalDisplayName": "(Asia Pacific) Southeast Asia (Stage)",
+      "type": "Region"
+    },
+    {
+      "displayName": "Brazil US",
+      "id": "/locations/brazilus",
+      "metadata": {
+        "geography": "Brazil",
+        "geographyGroup": "South America",
+        "latitude": "0",
+        "longitude": "0",
+        "pairedRegion": [
+          {
+            "id": "/locations/brazilsoutheast",
+            "name": "brazilsoutheast"
+          }
+        ],
+        "physicalLocation": "",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "brazilus",
+      "regionalDisplayName": "(South America) Brazil US",
+      "type": "Region"
+    },
+    {
+      "displayName": "North Central US",
+      "id": "/locations/northcentralus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "41.8819",
+        "longitude": "-87.6278",
+        "pairedRegion": [
+          {
+            "id": "/locations/southcentralus",
+            "name": "southcentralus"
+          }
+        ],
+        "physicalLocation": "Illinois",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "northcentralus",
+      "regionalDisplayName": "(US) North Central US",
+      "type": "Region"
+    },
+    {
+      "displayName": "West US",
+      "id": "/locations/westus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "37.783",
+        "longitude": "-122.417",
+        "pairedRegion": [
+          {
+            "id": "/locations/eastus",
+            "name": "eastus"
+          }
+        ],
+        "physicalLocation": "California",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "westus",
+      "regionalDisplayName": "(US) West US",
+      "type": "Region"
+    },
+    {
+      "displayName": "Jio India West",
+      "id": "/locations/jioindiawest",
+      "metadata": {
+        "geography": "India",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "22.470701",
+        "longitude": "70.05773",
+        "pairedRegion": [
+          {
+            "id": "/locations/jioindiacentral",
+            "name": "jioindiacentral"
+          }
+        ],
+        "physicalLocation": "Jamnagar",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "jioindiawest",
+      "regionalDisplayName": "(Asia Pacific) Jio India West",
+      "type": "Region"
+    },
+    {
+      "displayName": "West Central US",
+      "id": "/locations/westcentralus",
+      "metadata": {
+        "geography": "United States",
+        "geographyGroup": "US",
+        "latitude": "40.89",
+        "longitude": "-110.234",
+        "pairedRegion": [
+          {
+            "id": "/locations/westus2",
+            "name": "westus2"
+          }
+        ],
+        "physicalLocation": "Wyoming",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "westcentralus",
+      "regionalDisplayName": "(US) West Central US",
+      "type": "Region"
+    },
+    {
+      "displayName": "South Africa West",
+      "id": "/locations/southafricawest",
+      "metadata": {
+        "geography": "South Africa",
+        "geographyGroup": "Africa",
+        "latitude": "-34.075691",
+        "longitude": "18.843266",
+        "pairedRegion": [
+          {
+            "id": "/locations/southafricanorth",
+            "name": "southafricanorth"
+          }
+        ],
+        "physicalLocation": "Cape Town",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "southafricawest",
+      "regionalDisplayName": "(Africa) South Africa West",
+      "type": "Region"
+    },
+    {
+      "displayName": "Australia Central",
+      "id": "/locations/australiacentral",
+      "metadata": {
+        "geography": "Australia",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "-35.3075",
+        "longitude": "149.1244",
+        "pairedRegion": [
+          {
+            "id": "/locations/australiacentral2",
+            "name": "australiacentral2"
+          }
+        ],
+        "physicalLocation": "Canberra",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "australiacentral",
+      "regionalDisplayName": "(Asia Pacific) Australia Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Australia Central 2",
+      "id": "/locations/australiacentral2",
+      "metadata": {
+        "geography": "Australia",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "-35.3075",
+        "longitude": "149.1244",
+        "pairedRegion": [
+          {
+            "id": "/locations/australiacentral",
+            "name": "australiacentral"
+          }
+        ],
+        "physicalLocation": "Canberra",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "australiacentral2",
+      "regionalDisplayName": "(Asia Pacific) Australia Central 2",
+      "type": "Region"
+    },
+    {
+      "displayName": "Australia Southeast",
+      "id": "/locations/australiasoutheast",
+      "metadata": {
+        "geography": "Australia",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "-37.8136",
+        "longitude": "144.9631",
+        "pairedRegion": [
+          {
+            "id": "/locations/australiaeast",
+            "name": "australiaeast"
+          }
+        ],
+        "physicalLocation": "Victoria",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "australiasoutheast",
+      "regionalDisplayName": "(Asia Pacific) Australia Southeast",
+      "type": "Region"
+    },
+    {
+      "displayName": "Japan West",
+      "id": "/locations/japanwest",
+      "metadata": {
+        "geography": "Japan",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "34.6939",
+        "longitude": "135.5022",
+        "pairedRegion": [
+          {
+            "id": "/locations/japaneast",
+            "name": "japaneast"
+          }
+        ],
+        "physicalLocation": "Osaka",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "japanwest",
+      "regionalDisplayName": "(Asia Pacific) Japan West",
+      "type": "Region"
+    },
+    {
+      "displayName": "Jio India Central",
+      "id": "/locations/jioindiacentral",
+      "metadata": {
+        "geography": "India",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "21.146633",
+        "longitude": "79.08886",
+        "pairedRegion": [
+          {
+            "id": "/locations/jioindiawest",
+            "name": "jioindiawest"
+          }
+        ],
+        "physicalLocation": "Nagpur",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "jioindiacentral",
+      "regionalDisplayName": "(Asia Pacific) Jio India Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Korea South",
+      "id": "/locations/koreasouth",
+      "metadata": {
+        "geography": "Korea",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "35.1796",
+        "longitude": "129.0756",
+        "pairedRegion": [
+          {
+            "id": "/locations/koreacentral",
+            "name": "koreacentral"
+          }
+        ],
+        "physicalLocation": "Busan",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "koreasouth",
+      "regionalDisplayName": "(Asia Pacific) Korea South",
+      "type": "Region"
+    },
+    {
+      "displayName": "South India",
+      "id": "/locations/southindia",
+      "metadata": {
+        "geography": "India",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "12.9822",
+        "longitude": "80.1636",
+        "pairedRegion": [
+          {
+            "id": "/locations/centralindia",
+            "name": "centralindia"
+          }
+        ],
+        "physicalLocation": "Chennai",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "southindia",
+      "regionalDisplayName": "(Asia Pacific) South India",
+      "type": "Region"
+    },
+    {
+      "displayName": "West India",
+      "id": "/locations/westindia",
+      "metadata": {
+        "geography": "India",
+        "geographyGroup": "Asia Pacific",
+        "latitude": "19.088",
+        "longitude": "72.868",
+        "pairedRegion": [
+          {
+            "id": "/locations/southindia",
+            "name": "southindia"
+          }
+        ],
+        "physicalLocation": "Mumbai",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "westindia",
+      "regionalDisplayName": "(Asia Pacific) West India",
+      "type": "Region"
+    },
+    {
+      "displayName": "Canada East",
+      "id": "/locations/canadaeast",
+      "metadata": {
+        "geography": "Canada",
+        "geographyGroup": "Canada",
+        "latitude": "46.817",
+        "longitude": "-71.217",
+        "pairedRegion": [
+          {
+            "id": "/locations/canadacentral",
+            "name": "canadacentral"
+          }
+        ],
+        "physicalLocation": "Quebec",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "canadaeast",
+      "regionalDisplayName": "(Canada) Canada East",
+      "type": "Region"
+    },
+    {
+      "displayName": "France South",
+      "id": "/locations/francesouth",
+      "metadata": {
+        "geography": "France",
+        "geographyGroup": "Europe",
+        "latitude": "43.8345",
+        "longitude": "2.1972",
+        "pairedRegion": [
+          {
+            "id": "/locations/francecentral",
+            "name": "francecentral"
+          }
+        ],
+        "physicalLocation": "Marseille",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "francesouth",
+      "regionalDisplayName": "(Europe) France South",
+      "type": "Region"
+    },
+    {
+      "displayName": "Germany North",
+      "id": "/locations/germanynorth",
+      "metadata": {
+        "geography": "Germany",
+        "geographyGroup": "Europe",
+        "latitude": "53.073635",
+        "longitude": "8.806422",
+        "pairedRegion": [
+          {
+            "id": "/locations/germanywestcentral",
+            "name": "germanywestcentral"
+          }
+        ],
+        "physicalLocation": "Berlin",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "germanynorth",
+      "regionalDisplayName": "(Europe) Germany North",
+      "type": "Region"
+    },
+    {
+      "displayName": "Norway West",
+      "id": "/locations/norwaywest",
+      "metadata": {
+        "geography": "Norway",
+        "geographyGroup": "Europe",
+        "latitude": "58.969975",
+        "longitude": "5.733107",
+        "pairedRegion": [
+          {
+            "id": "/locations/norwayeast",
+            "name": "norwayeast"
+          }
+        ],
+        "physicalLocation": "Norway",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "norwaywest",
+      "regionalDisplayName": "(Europe) Norway West",
+      "type": "Region"
+    },
+    {
+      "displayName": "Switzerland West",
+      "id": "/locations/switzerlandwest",
+      "metadata": {
+        "geography": "Switzerland",
+        "geographyGroup": "Europe",
+        "latitude": "46.204391",
+        "longitude": "6.143158",
+        "pairedRegion": [
+          {
+            "id": "/locations/switzerlandnorth",
+            "name": "switzerlandnorth"
+          }
+        ],
+        "physicalLocation": "Geneva",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "switzerlandwest",
+      "regionalDisplayName": "(Europe) Switzerland West",
+      "type": "Region"
+    },
+    {
+      "displayName": "UK West",
+      "id": "/locations/ukwest",
+      "metadata": {
+        "geography": "United Kingdom",
+        "geographyGroup": "Europe",
+        "latitude": "53.427",
+        "longitude": "-3.084",
+        "pairedRegion": [
+          {
+            "id": "/locations/uksouth",
+            "name": "uksouth"
+          }
+        ],
+        "physicalLocation": "Cardiff",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "ukwest",
+      "regionalDisplayName": "(Europe) UK West",
+      "type": "Region"
+    },
+    {
+      "displayName": "UAE Central",
+      "id": "/locations/uaecentral",
+      "metadata": {
+        "geography": "UAE",
+        "geographyGroup": "Middle East",
+        "latitude": "24.466667",
+        "longitude": "54.366669",
+        "pairedRegion": [
+          {
+            "id": "/locations/uaenorth",
+            "name": "uaenorth"
+          }
+        ],
+        "physicalLocation": "Abu Dhabi",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "uaecentral",
+      "regionalDisplayName": "(Middle East) UAE Central",
+      "type": "Region"
+    },
+    {
+      "displayName": "Brazil Southeast",
+      "id": "/locations/brazilsoutheast",
+      "metadata": {
+        "geography": "Brazil",
+        "geographyGroup": "South America",
+        "latitude": "-22.90278",
+        "longitude": "-43.2075",
+        "pairedRegion": [
+          {
+            "id": "/locations/brazilsouth",
+            "name": "brazilsouth"
+          }
+        ],
+        "physicalLocation": "Rio",
+        "regionCategory": "Other",
+        "regionType": "Physical"
+      },
+      "name": "brazilsoutheast",
+      "regionalDisplayName": "(South America) Brazil Southeast",
+      "type": "Region"
+    }
+  ]
+}

--- a/data/microsoft.compute_resourceTypes.json
+++ b/data/microsoft.compute_resourceTypes.json
@@ -1,0 +1,6803 @@
+{
+  "resourceTypes": [
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "availabilitySets"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachines",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachines/extensions"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-10-30-preview",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-10-30-preview",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2015-06-15",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/extensions"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-10-30-preview",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/virtualMachines"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-10-30-preview",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/virtualMachines/extensions"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-09-01",
+        "2016-08-01",
+        "2016-07-01",
+        "2016-06-01",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/networkInterfaces"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-09-01",
+        "2016-08-01",
+        "2016-07-01",
+        "2016-06-01",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/virtualMachines/networkInterfaces"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/publicIPAddresses"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [],
+      "resourceType": "locations"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-10-30-preview",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/operations"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/vmSizes"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/runCommands"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/virtualMachines"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/virtualMachineScaleSets"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-03",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-03",
+        "2022-08-01",
+        "2022-03-03",
+        "2022-03-01",
+        "2022-01-03",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/publishers"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "operations"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachines/runCommands"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/applications"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachines/VMApplications"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01"
+      ],
+      "capabilities": "None",
+      "locations": [],
+      "resourceType": "locations/edgeZones"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/edgeZones/vmimages"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/edgeZones/publishers"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "restorePointCollections"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "restorePointCollections/restorePoints"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "proximityPlacementGroups",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "sshPublicKeys"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "capacityReservationGroups",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "capacityReservationGroups/capacityReservations",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiVersions": [
+        "2014-04-01"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Israel Central",
+        "Poland Central",
+        "Italy North"
+      ],
+      "resourceType": "virtualMachines/metricDefinitions"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/spotEvictionRates"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/spotPriceHistory"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/recommendations"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-03",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-03",
+        "2022-08-01",
+        "2022-03-03",
+        "2022-03-01",
+        "2022-01-03",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/sharedGalleries"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-03",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-03",
+        "2022-08-01",
+        "2022-03-03",
+        "2022-03-01",
+        "2022-01-03",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/communityGalleries"
+    },
+    {
+      "apiVersions": [
+        "2017-10-15-preview"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2017-10-15-preview",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central"
+      ],
+      "resourceType": "sharedVMImages"
+    },
+    {
+      "apiVersions": [
+        "2017-10-15-preview"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2017-10-15-preview",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central"
+      ],
+      "resourceType": "sharedVMImages/versions"
+    },
+    {
+      "apiVersions": [
+        "2017-10-15-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central"
+      ],
+      "resourceType": "locations/artifactPublishers"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-06-01",
+        "2017-10-15-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/capsoperations"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-06-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2018-06-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "galleries"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-06-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2018-06-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "galleries/images"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-06-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2018-06-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "galleries/images/versions"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-06-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2018-06-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/galleries"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03"
+      ],
+      "capabilities": "None",
+      "locations": [],
+      "resourceType": "payloadGroups"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2019-03-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "galleries/applications"
+    },
+    {
+      "apiVersions": [
+        "2023-07-03",
+        "2022-08-03",
+        "2022-03-03",
+        "2022-01-03",
+        "2021-10-01",
+        "2021-07-01",
+        "2021-03-01",
+        "2020-09-30",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2019-03-01",
+      "locations": [
+        "West Central US",
+        "South Central US",
+        "East US 2",
+        "Southeast Asia",
+        "West Europe",
+        "West US",
+        "East US",
+        "Canada Central",
+        "North Europe",
+        "North Central US",
+        "Brazil South",
+        "UK West",
+        "West India",
+        "East Asia",
+        "Australia East",
+        "Japan East",
+        "Korea South",
+        "West US 2",
+        "Canada East",
+        "UK South",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Japan West",
+        "Korea Central",
+        "France Central",
+        "Central US",
+        "Australia Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "galleries/applications/versions"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2018-04-01",
+          "profileVersion": "2018-06-01-profile"
+        }
+      ],
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01",
+        "2019-11-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-09-30",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-03-30",
+        "2016-04-30-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "disks",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2018-04-01",
+          "profileVersion": "2018-06-01-profile"
+        }
+      ],
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01",
+        "2019-11-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-09-30",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-03-30",
+        "2016-04-30-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "snapshots"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2018-04-01",
+          "profileVersion": "2018-06-01-profile"
+        }
+      ],
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01",
+        "2019-11-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-09-30",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-03-30",
+        "2016-04-30-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/diskoperations"
+    },
+    {
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01",
+        "2019-11-01",
+        "2019-07-01"
+      ],
+      "capabilities": "SystemAssignedResourceIdentity, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "diskEncryptionSets"
+    },
+    {
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "diskAccesses"
+    },
+    {
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "restorePointCollections/restorePoints/diskRestorePoints"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2018-04-01",
+          "profileVersion": "2018-06-01-profile"
+        }
+      ],
+      "apiVersions": [
+        "2023-10-02",
+        "2023-04-02",
+        "2023-01-02",
+        "2022-07-02",
+        "2022-03-02",
+        "2021-12-01",
+        "2021-08-01",
+        "2021-04-01",
+        "2020-12-01",
+        "2020-09-30",
+        "2020-06-30",
+        "2020-05-01",
+        "2019-11-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-09-30",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-03-30",
+        "2016-04-30-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-02",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "virtualMachineScaleSets/disks"
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2021-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices/roles"
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices/roleInstances"
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/csoperations"
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/cloudServiceOsVersions"
+    },
+    {
+      "apiVersions": [
+        "2022-09-04",
+        "2022-04-04",
+        "2021-03-01"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/cloudServiceOsFamilies"
+    },
+    {
+      "apiVersions": [
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices/networkInterfaces"
+    },
+    {
+      "apiVersions": [
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices/roleInstances/networkInterfaces"
+    },
+    {
+      "apiVersions": [
+        "2021-03-01",
+        "2020-10-01-preview"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "cloudServices/publicIPAddresses"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2016-03-30",
+          "profileVersion": "2017-03-09-profile"
+        },
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2018-06-01-profile"
+        },
+        {
+          "apiVersion": "2017-12-01",
+          "profileVersion": "2019-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2020-06-01",
+          "profileVersion": "2020-09-01-hybrid"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview",
+        "2016-03-30",
+        "2015-06-15",
+        "2015-05-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/usages"
+    },
+    {
+      "apiProfiles": [
+        {
+          "apiVersion": "2017-03-30",
+          "profileVersion": "2018-03-01-hybrid"
+        },
+        {
+          "apiVersion": "2018-04-01",
+          "profileVersion": "2018-06-01-profile"
+        }
+      ],
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01",
+        "2017-03-30",
+        "2016-08-30",
+        "2016-04-30-preview"
+      ],
+      "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "Southeast Asia",
+        "East US 2",
+        "Central US",
+        "West Europe",
+        "East US",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "North Europe",
+        "East Asia",
+        "Brazil South",
+        "West US 2",
+        "West Central US",
+        "UK West",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "Canada Central",
+        "Canada East",
+        "Central India",
+        "South India",
+        "Australia East",
+        "Australia Southeast",
+        "Korea Central",
+        "Korea South",
+        "West India",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "images"
+    },
+    {
+      "apiVersions": [
+        "2021-06-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-06-01-preview",
+      "locations": [
+        "West Central US",
+        "Southeast Asia",
+        "East US 2",
+        "East US",
+        "South Central US",
+        "West Europe",
+        "North Europe",
+        "West US 2",
+        "UK South",
+        "Australia East",
+        "South India",
+        "Central India",
+        "West India",
+        "Korea Central",
+        "Korea South",
+        "Japan West",
+        "Japan East",
+        "East Asia",
+        "Canada Central",
+        "Canada East",
+        "South Africa North",
+        "Central US",
+        "West US 3",
+        "West US",
+        "UK West",
+        "France Central",
+        "UAE North",
+        "Australia Central",
+        "Australia Southeast",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "North Central US",
+        "Brazil South",
+        "Sweden Central"
+      ],
+      "resourceType": "locations/diagnostics"
+    },
+    {
+      "apiVersions": [
+        "2021-06-01-preview"
+      ],
+      "capabilities": "None",
+      "defaultApiVersion": "2021-06-01-preview",
+      "locations": [
+        "West Central US",
+        "Southeast Asia",
+        "East US 2",
+        "East US",
+        "South Central US",
+        "West Europe",
+        "North Europe",
+        "West US 2",
+        "UK South",
+        "Australia East",
+        "South India",
+        "Central India",
+        "West India",
+        "Korea Central",
+        "Korea South",
+        "Japan West",
+        "Japan East",
+        "East Asia",
+        "Canada Central",
+        "Canada East",
+        "South Africa North",
+        "Central US",
+        "West US 3",
+        "West US",
+        "UK West",
+        "France Central",
+        "UAE North",
+        "Australia Central",
+        "Australia Southeast",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "North Central US",
+        "Brazil South",
+        "Sweden Central"
+      ],
+      "resourceType": "locations/diagnosticOperations"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01",
+        "2018-06-01",
+        "2018-04-01",
+        "2017-12-01"
+      ],
+      "capabilities": "None",
+      "locations": [
+        "East US",
+        "East US 2",
+        "West US",
+        "Central US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan East",
+        "Japan West",
+        "Australia East",
+        "Australia Southeast",
+        "Australia Central",
+        "Brazil South",
+        "South India",
+        "Central India",
+        "West India",
+        "Canada Central",
+        "Canada East",
+        "West US 2",
+        "West Central US",
+        "UK South",
+        "UK West",
+        "Korea Central",
+        "Korea South",
+        "France Central",
+        "South Africa North",
+        "UAE North",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "locations/logAnalytics"
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "Central US",
+        "East US 2",
+        "West Europe",
+        "Southeast Asia",
+        "France Central",
+        "North Europe",
+        "West US 2",
+        "East US",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "East Asia",
+        "North Central US",
+        "South Central US",
+        "Canada East",
+        "Korea Central",
+        "Brazil South",
+        "UK West",
+        "Canada Central",
+        "West US",
+        "West Central US",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Korea South",
+        "West India",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "Australia East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "hostGroups",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    },
+    {
+      "apiVersions": [
+        "2024-03-01",
+        "2023-09-01",
+        "2023-07-01",
+        "2023-03-01",
+        "2022-11-01",
+        "2022-08-01",
+        "2022-03-01",
+        "2021-11-01",
+        "2021-07-01",
+        "2021-04-01",
+        "2021-03-01",
+        "2020-12-01",
+        "2020-06-01",
+        "2019-12-01",
+        "2019-07-01",
+        "2019-03-01",
+        "2018-10-01"
+      ],
+      "capabilities": "SupportsTags, SupportsLocation",
+      "defaultApiVersion": "2022-03-01",
+      "locations": [
+        "Central US",
+        "East US 2",
+        "West Europe",
+        "Southeast Asia",
+        "France Central",
+        "North Europe",
+        "West US 2",
+        "East US",
+        "UK South",
+        "Japan East",
+        "Japan West",
+        "East Asia",
+        "North Central US",
+        "South Central US",
+        "Canada East",
+        "Korea Central",
+        "Brazil South",
+        "UK West",
+        "Canada Central",
+        "West US",
+        "West Central US",
+        "Central India",
+        "South India",
+        "Australia Southeast",
+        "Korea South",
+        "West India",
+        "South Africa North",
+        "UAE North",
+        "Australia Central",
+        "Switzerland North",
+        "Germany West Central",
+        "Norway East",
+        "Australia East",
+        "West US 3",
+        "Sweden Central",
+        "Qatar Central",
+        "Poland Central",
+        "Italy North",
+        "Israel Central"
+      ],
+      "resourceType": "hostGroups/hosts",
+      "zoneMappings": [
+        {
+          "location": "Australia East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Brazil South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Canada Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central India",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "East US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "France Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Germany West Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Japan East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Korea Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "North Central US",
+          "zones": []
+        },
+        {
+          "location": "North Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Norway East",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Qatar Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Africa North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "South Central US",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Southeast Asia",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Sweden Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Switzerland North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UAE North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "UK South",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West Europe",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US",
+          "zones": []
+        },
+        {
+          "location": "West US 2",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "West US 3",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Israel Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Italy North",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        },
+        {
+          "location": "Poland Central",
+          "zones": [
+            "1",
+            "3",
+            "2"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
-# Default example
+# AKS cluster with region having availability zone
 
-This deploys the module in its simplest form.
+This deploys the module with a region that has availability zones.
 
 ```hcl
 terraform {
@@ -11,10 +11,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.5.0, < 4.0.0"
-    }
   }
 }
 
@@ -22,31 +18,17 @@ provider "azurerm" {
   features {}
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = ">= 0.3.0"
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  name     = module.naming.resource_group.name_unique
 }
 
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
 
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
   version = ">= 0.3.0"
-}
-
-# This is required for resource modules
-resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
-  name     = module.naming.resource_group.name_unique
 }
 
 resource "azurerm_user_assigned_identity" "this" {
@@ -66,8 +48,26 @@ module "test" {
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
-  location            = "East US" # Hardcoded instead of using module.regions because The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
   identity_ids        = [azurerm_user_assigned_identity.this.id]
+  location            = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  node_pools = {
+    workload = {
+      name      = "workload"
+      vm_size   = "Standard_D2d_v5"
+      max_count = 110
+      min_count = 2
+      os_sku    = "Ubuntu"
+      mode      = "User"
+    },
+    ingress = {
+      name      = "ingress"
+      vm_size   = "Standard_D2d_v5"
+      max_count = 4
+      min_count = 2
+      os_sku    = "Ubuntu"
+      mode      = "User"
+    }
+  }
 }
 ```
 
@@ -80,15 +80,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.7.0, < 4.0.0)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
-
 ## Providers
 
 The following providers are used by this module:
 
 - <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.7.0, < 4.0.0)
-
-- <a name="provider_random"></a> [random](#provider\_random) (>= 3.5.0, < 4.0.0)
 
 ## Resources
 
@@ -96,7 +92,6 @@ The following resources are used by this module:
 
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
-- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -136,12 +131,6 @@ The following Modules are called:
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
 Source: Azure/naming/azurerm
-
-Version: >= 0.3.0
-
-### <a name="module_regions"></a> [regions](#module\_regions)
-
-Source: Azure/regions/azurerm
 
 Version: >= 0.3.0
 

--- a/examples/with_availability_zone/_footer.md
+++ b/examples/with_availability_zone/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/with_availability_zone/_header.md
+++ b/examples/with_availability_zone/_header.md
@@ -1,0 +1,3 @@
+# AKS cluster with region having availability zone
+
+This deploys the module with a region that has availability zones.

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.5.0, < 4.0.0"
-    }
   }
 }
 
@@ -16,31 +12,17 @@ provider "azurerm" {
   features {}
 }
 
-
-## Section to provide a random Azure region for the resource group
-# This allows us to randomize the region for the resource group.
-module "regions" {
-  source  = "Azure/regions/azurerm"
-  version = ">= 0.3.0"
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  name     = module.naming.resource_group.name_unique
 }
 
-# This allows us to randomize the region for the resource group.
-resource "random_integer" "region_index" {
-  max = length(module.regions.regions) - 1
-  min = 0
-}
-## End of section to provide a random Azure region for the resource group
 
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
   version = ">= 0.3.0"
-}
-
-# This is required for resource modules
-resource "azurerm_resource_group" "this" {
-  location = module.regions.regions[random_integer.region_index.result].name
-  name     = module.naming.resource_group.name_unique
 }
 
 resource "azurerm_user_assigned_identity" "this" {
@@ -60,6 +42,24 @@ module "test" {
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
-  location            = "East US" # Hardcoded instead of using module.regions because The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
   identity_ids        = [azurerm_user_assigned_identity.this.id]
+  location            = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  node_pools = {
+    workload = {
+      name      = "workload"
+      vm_size   = "Standard_D2d_v5"
+      max_count = 110
+      min_count = 2
+      os_sku    = "Ubuntu"
+      mode      = "User"
+    },
+    ingress = {
+      name      = "ingress"
+      vm_size   = "Standard_D2d_v5"
+      max_count = 4
+      min_count = 2
+      os_sku    = "Ubuntu"
+      mode      = "User"
+    }
+  }
 }

--- a/examples/with_availability_zone/variables.tf
+++ b/examples/with_availability_zone/variables.tf
@@ -1,0 +1,15 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "kubernetes_cluster_name" {
+  type        = string
+  default     = "myAks"
+  description = "The name of the Kubernetes cluster."
+}

--- a/examples/without_availability_zone/_footer.md
+++ b/examples/without_availability_zone/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/without_availability_zone/_header.md
+++ b/examples/without_availability_zone/_header.md
@@ -1,0 +1,3 @@
+# AKS cluster without availability zones
+
+This deploys the module with a region that has no availability zones.

--- a/examples/without_availability_zone/variables.tf
+++ b/examples/without_availability_zone/variables.tf
@@ -1,0 +1,15 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "kubernetes_cluster_name" {
+  type        = string
+  default     = "myAks"
+  description = "The name of the Kubernetes cluster."
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,4 @@
-# TODO: insert locals here.
 locals {
-  resource_group_location            = try(data.azurerm_resource_group.parent[0].location, null)
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }
 
@@ -16,4 +14,49 @@ locals {
       }
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
+}
+
+
+locals {
+  locations_cached_or_live        = data.local_file.locations.content
+  regions_by_display_name         = { for v in local.regions_recommended_or_not : v.display_name => v }
+  regions_by_name                 = { for v in local.regions_recommended_or_not : v.name => v }
+  regions_by_name_or_display_name = merge(local.regions_by_display_name, local.regions_by_name)
+  regions_data_merged = [
+    for v in jsondecode(local.locations_cached_or_live).value :
+    merge(
+      {
+        name               = v.name
+        display_name       = v.displayName
+        paired_region_name = try(one(v.metadata.pairedRegion).name, null)
+        geography          = v.metadata.geography
+        geography_group    = v.metadata.geographyGroup
+        recommended        = v.metadata.regionCategory == "Recommended"
+      },
+      {
+        zones = sort(lookup(local.regions_to_zones_map, v.displayName, []))
+      }
+    ) if v.metadata.regionType == "Physical"
+  ]
+  # Filter out regions that are not recommended
+  regions_recommended_or_not          = [for v in local.regions_data_merged : v if v.recommended]
+  regions_to_zones_map                = { for v in local.regions_zonemappings : v.location => v.zones }
+  regions_zonemappings                = flatten([for v in jsondecode(local.regions_zonemappings_cached_or_live).resourceTypes : v.zoneMappings if v.resourceType == "virtualMachines"])
+  regions_zonemappings_cached_or_live = data.local_file.compute_provider.content
+}
+locals {
+  # Flatten a list of var.node_pools and zones
+  node_pools = flatten([
+    for pool in var.node_pools : [
+      for zone in try(local.regions_by_name_or_display_name[var.location].zones, [""]) : {
+        # concatenate name and zone trim to 12 characters
+        name      = "${substr(pool.name, 0, 11)}${zone}"
+        vm_size   = pool.vm_size
+        max_count = pool.max_count
+        min_count = pool.min_count
+        os_sku    = pool.os_sku
+        zone      = zone
+      }
+    ]
+  ])
 }

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -2,7 +2,7 @@
 resource "azurerm_private_endpoint" "this" {
   for_each = var.private_endpoints
 
-  location                      = coalesce(each.value.location, var.location, local.resource_group_location)
+  location                      = coalesce(each.value.location, var.location)
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,10 +1,13 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    # TODO: Ensure all required providers are listed here.
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.71.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.1"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This is a refactory of PR #9 

* Resync with updated AVM template using `grept`
* Enforce autoscaling ( as per design doc )
* Enforce the creation of 3 zonal node pools when the region supports zones.

